### PR TITLE
Fixed build scripts to create macos application bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+build_app/
+.DS_Store

--- a/cross-compile/macosx/contrib/Info-smuview.plist
+++ b/cross-compile/macosx/contrib/Info-smuview.plist
@@ -1,20 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>CFBundleIconFile</key>
-	<string>smuview.icns</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleGetInfoString</key>
-	<string>SmuView is a Qt based source measure unit GUI for sigrok.</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleExecutable</key>
 	<string>smuview</string>
+	<key>CFBundleGetInfoString</key>
+	<string>SmuView is a Qt based source measure unit GUI for sigrok.</string>
+	<key>CFBundleIconFile</key>
+	<string>smuview.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.sigrok.SmuView</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>SmuView</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.0.0</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/cross-compile/macosx/contrib/Info-smuview.xslt
+++ b/cross-compile/macosx/contrib/Info-smuview.xslt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="no"/> 
+
+	<xsl:template match="@*|node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="string[preceding-sibling::key[1][text() = 'CFBundleVersion' or text() = 'CFBundleShortVersionString']]">
+		<string><xsl:value-of select="$VERSION" /></string>
+	</xsl:template>
+
+</xsl:stylesheet> 

--- a/cross-compile/macosx/create_dmg-smuview
+++ b/cross-compile/macosx/create_dmg-smuview
@@ -28,16 +28,13 @@ BUILDDIR=./build_app
 
 # We use Qt 5.5 in order to remain compatible with more versions of Mac OS X.
 # TODO: Use Qt >= 5.7
-QTVER=qt@5.5
+QTVER=qt
 
 # Path to Qt5 binaries.
 QTBINDIR=`brew list $QTVER | grep bin | head -n 1 | xargs dirname`
 
-# Path to boost libraries.
-BOOSTLIBDIR=`brew list boost | grep libboost_system | head -n 1 | xargs dirname`
-
 # Path to Python 3 framework.
-PYTHONFRAMEWORKDIR=`brew list python3 | grep Python.framework | head -n 1 | xargs dirname`/../../../..
+PYTHONFRAMEWORKDIR=`brew list python3 | grep Python.framework/Python | head -n 1 | xargs dirname`
 
 PYVER="3.7"
 
@@ -52,22 +49,16 @@ cd $BUILDDIR
 
 APPNAME="SmuView"
 APPNAME_BINARY="smuview"
-APPVER="NIGHTLY"
+APPVER="0.0.4"
 
 CONTENTSDIR="$APPNAME.app/Contents"
 MACOSDIR="$CONTENTSDIR/MacOS"
 FRAMEWORKSDIR="$CONTENTSDIR/Frameworks"
-SHARE_DIR="$CONTENTSDIR/share"
 PYDIR="$FRAMEWORKSDIR/Python.framework/Versions/$PYVER"
 
-mkdir -p $MACOSDIR $FRAMEWORKSDIR $SHARE_DIR
+mkdir -p $MACOSDIR $FRAMEWORKSDIR
 
 cp $PREFIX/bin/$APPNAME_BINARY $MACOSDIR
-
-# Manually copy some boost libs that "macdeployqt" won't copy.
-cp $BOOSTLIBDIR/libboost_timer-mt.dylib $FRAMEWORKSDIR
-cp $BOOSTLIBDIR/libboost_chrono-mt.dylib $FRAMEWORKSDIR
-chmod 644 $FRAMEWORKSDIR/*boost*
 
 $QTBINDIR/macdeployqt $APPNAME.app
 
@@ -94,14 +85,14 @@ rm -rf $PYDIR/Resources
 install_name_tool -change \
 	/usr/local/opt/python/Frameworks/Python.framework/Versions/$PYVER/Python \
 	@executable_path/../Frameworks/Python.framework/Versions/$PYVER/Python \
-	$FRAMEWORKSDIR/libsigrokdecode.*.dylib
+	$MACOSDIR/$APPNAME_BINARY
 
 # Add SmuView wrapper (sets PYTHONHOME).
 mv $MACOSDIR/$APPNAME_BINARY $MACOSDIR/$APPNAME_BINARY.real
 cp ../contrib/smuview $MACOSDIR
 chmod 755 $MACOSDIR/$APPNAME_BINARY
 
-cp ../contrib/Info-smuview.plist $CONTENTSDIR/Info.plist
+xsltproc --stringparam VERSION "${APPVER}" -o $CONTENTSDIR/Info.plist ../contrib/Info-smuview.xslt ../contrib/Info-smuview.plist
 cp ../contrib/smuview.icns $CONTENTSDIR/Resources
 
 hdiutil create "${APPNAME}-${APPVER}.dmg" -volname "$APPNAME $APPVER" \

--- a/cross-compile/macosx/sigrok-native-macosx-smuview
+++ b/cross-compile/macosx/sigrok-native-macosx-smuview
@@ -47,7 +47,7 @@ export CXX=g++
 
 # We use Qt 5.5 in order to remain compatible with more versions of Mac OS X.
 # TODO: Use Qt >= 5.7
-QTVER=qt@5.5
+QTVER=qt
 
 # Path to Qt5 binaries (needed for cmake to find the Qt5 libs).
 export PATH="$(brew --prefix $QTVER)/bin:$PATH"


### PR DESCRIPTION
Uses the currently installed version of Qt since HomeBrew offers currently no possibility to choose between different qt versions.
The Version code placed in create_dmg-smuview $APPVER is automatically transferred into Info.plist and added to the application bundle 